### PR TITLE
Fix bug: add missing flag

### DIFF
--- a/reactive/vnf_user.py
+++ b/reactive/vnf_user.py
@@ -15,6 +15,7 @@ from charms.reactive import (
 import random
 
 
+@when('sshproxy.configured')
 @when_not('vnf-user.installed')
 def install_vnf_user():
     set_flag('vnf-a.installed')


### PR DESCRIPTION
Hello Adam,

In the function `install_vnf_user()` we have to check the flag `sshproxy.configured`.

That was missing, and OSM wasn't waiting for the VM to be up and running. Therefore, this error was happening:

```
ERROR execute charm primitive generate-ssh-public-key for member_vnf_index=1 vdu_id=userVM: error executing primitive generate-ssh-key: {}
```

This PR should fix that. I've tested it.

```
Model                                 Controller  Cloud/Region         Version  SLA          Timestamp
dbd74c52-fb33-48c1-8acf-697a0236bea4  osm-lxd     localhost/localhost  2.6.9    unsupported  09:21:34Z

App                         Version  Status   Scale  Charm       Store  Rev  OS      Notes
test-nscharm-ac                      blocked      1  ns          local    0  ubuntu  
test-nscharm-b-uservm-aa             active       1  vnf-user    local    0  ubuntu  
test-nscharm-c-policyvm-ab           active       1  vnf-policy  local    0  ubuntu  

Unit                           Workload  Agent  Machine  Public address  Ports  Message
test-nscharm-ac/0*             blocked   idle   2        10.35.242.211          Verification failed: Invalid IP address.
test-nscharm-b-uservm-aa/0*    active    idle   1        10.35.242.120          Ready!
test-nscharm-c-policyvm-ab/0*  active    idle   0        10.35.242.214          Ready!

Machine  State    DNS            Inst id        Series  AZ  Message
0        started  10.35.242.214  juju-dfdc51-0  xenial      Running
1        started  10.35.242.120  juju-dfdc51-1  xenial      Running
2        started  10.35.242.211  juju-dfdc51-2  xenial      Running
```